### PR TITLE
Improve pyLDAvis example

### DIFF
--- a/examples/lda_visualization.py
+++ b/examples/lda_visualization.py
@@ -59,6 +59,8 @@ prepared_data = pyLDAvis.prepare(
     doc_topic_dists, 
     doc_lengths, 
     vocab, 
-    term_frequency
+    term_frequency,
+    start_index=0, # tomotopy starts topic ids with 0, pyLDAvis with 1
+    sort_topics=False # IMPORTANT: otherwise the topic_ids between pyLDAvis and tomotopy are not matching!
 )
 pyLDAvis.save_html(prepared_data, 'ldavis.html')


### PR DESCRIPTION
Override non-intuitive parameters with more appropriate values to better match the expectations of tomotopy users who are not familiar with the internals of pyLDAvis.
This way `mdl.summary()` matches better with the produced visualization by pyLDAvis.
A similar issue is discussed here: https://github.com/bmabey/pyLDAvis/issues/127