### PR TITLE
Fix integer overflow in LDA partition bookkeeping for large corpora

### DIFF
--- a/src/TopicModel/LDAModel.hpp
+++ b/src/TopicModel/LDAModel.hpp
@@ -440,8 +440,9 @@ namespace tomoto
 			if (edd.vChunkOffset.size() != numPools)
 			{
 				edd.vChunkOffset.clear();
-				size_t totCnt = std::accumulate(this->vocabCf.begin(), this->vocabCf.begin() + this->realV, 0);
-				size_t cumCnt = 0;
+				// Keep partition bookkeeping in 64-bit space for corpora whose total token count exceeds INT32_MAX.
+				uint64_t totCnt = std::accumulate(this->vocabCf.begin(), this->vocabCf.begin() + this->realV, uint64_t{0});
+				uint64_t cumCnt = 0;
 				for (size_t i = 0; i < this->realV; ++i)
 				{
 					cumCnt += this->vocabCf[i];
@@ -1087,7 +1088,7 @@ namespace tomoto
 			if (initDocs)
 			{
 				std::vector<uint32_t> df, cf, tf;
-				size_t totCf;
+				uint64_t totCf;
 
 				// calculate weighting
 				if (_tw != TermWeight::one)
@@ -1102,7 +1103,7 @@ namespace tomoto
 							++df[w];
 						}
 					}
-					totCf = std::accumulate(this->vocabCf.begin(), this->vocabCf.end(), 0);
+					totCf = std::accumulate(this->vocabCf.begin(), this->vocabCf.end(), uint64_t{0});
 				}
 				if (_tw == TermWeight::idf)
 				{


### PR DESCRIPTION
## Summary

This fixes integer overflow in the LDA multi-worker partition path for very large corpora.

## Root cause

`LDAModel::updatePartition()` accumulated total token counts with a literal `0`, which makes `std::accumulate` sum in 32-bit integer space before assigning back to a wider type.

For corpora whose total token count exceeds `INT32_MAX`, this can overflow and corrupt partition bookkeeping in the `PARTITION` path.

## Changes

- use `uint64_t` for the partition total-count accumulator
- use `uint64_t` for the partition cumulative-count accumulator
- use `uint64_t` for `totCf` in the term-weighting path

## Notes

This change is intended to preserve behavior for normal corpora while avoiding overflow for large-token inputs.